### PR TITLE
Change iOS platform target to iOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "FlipperLite",
-    platforms: [.iOS(.v15), .macOS(.v12)],
+    platforms: [.iOS(.v14), .macOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
I would like to use FlipperLite with an app that still targets iOS 14. There doesn't seem to be anything specific to iOS 15+ in FlipperLite so simply changing the package platform version for iOS should be enough.